### PR TITLE
add mock server and run_server, run_client scripts

### DIFF
--- a/controllers/mock/__init__.py
+++ b/controllers/mock/__init__.py
@@ -1,0 +1,1 @@
+from .models import Pose, Position, QuaternionOrientation

--- a/controllers/mock/models.py
+++ b/controllers/mock/models.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class Position(BaseModel):
+    x: float
+    y: float
+    z: float
+
+
+class QuaternionOrientation(BaseModel):
+    q1: float
+    q2: float
+    q3: float
+    q4: float
+
+
+class Pose(BaseModel):
+    position: Position
+    orientation: QuaternionOrientation

--- a/controllers/mock/server.py
+++ b/controllers/mock/server.py
@@ -22,7 +22,7 @@ class MockServer:
             "06": self.set_tool,
         }
 
-    def run(self):
+    def run(self) -> None:
         self.connection.listen(5)
         print(f"Server listening on port: {self.port}")
         self.connection, addr = self.connection.accept()
@@ -63,7 +63,7 @@ class MockServer:
         action, parameters = instruction[0], instruction[1:]
         return action, parameters
 
-    def get_function(self, action) -> Callable[[any], None] | None:
+    def get_function(self, action:str) -> Callable[[any], None] | None:
         if action not in self.function_dict.keys():
             print(f"[ERROR] Invalid action {action}")
             return None

--- a/controllers/mock/server.py
+++ b/controllers/mock/server.py
@@ -63,27 +63,27 @@ class MockServer:
         action, parameters = instruction[0], instruction[1:]
         return action, parameters
 
-    def get_function(self, action:str) -> Callable[[any], None] | None:
+    def get_function(self, action: str) -> Callable[[any], None] | None:
         if action not in self.function_dict.keys():
             print(f"[ERROR] Invalid action {action}")
             return None
 
         return self.function_dict[action]
 
-    def get_joints(self):
+    def get_joints(self) -> None:
         """
         Returns the current angles of the robots joints, in degrees.
         """
         print("Recieved get_joints action")
 
-    def set_joints(self, joints):
+    def set_joints(self, joints: list) -> None:
         """
         Executes a move immediately, from current joint angles,
         to 'joints', in degrees.
         """
         print(f"Recieved set_joints action with parameters: {joints}")
 
-    def set_tool(self, tool=[[0, 0, 0], [1, 0, 0, 0]]):
+    def set_tool(self, tool: list = [[0, 0, 0], [1, 0, 0, 0]]) -> None:
         print(f"Recieved set_tool action with parameters: {tool}")
 
     def move_tcp(self, pose: Pose) -> None:

--- a/controllers/mock/server.py
+++ b/controllers/mock/server.py
@@ -1,0 +1,95 @@
+import os
+import json
+import socket
+from typing_extensions import Callable
+
+from .models import Pose
+
+
+class MockServer:
+    def __init__(self, port: int = 5000) -> None:
+        self.port = int(os.environ.get("PORT", str(port)))
+
+        self.connection = socket.socket()
+        # next line allows for port reuse
+        self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        self.connection.bind(("", self.port))
+        self.function_dict = {
+            "01": self.move_tcp,
+            "02": self.set_joints,
+            "04": self.get_joints,
+            "06": self.set_tool,
+        }
+
+    def run(self):
+        self.connection.listen(5)
+        print(f"Server listening on port: {self.port}")
+        self.connection, addr = self.connection.accept()
+        self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        with self.connection:
+            print(f"Accepted connection from: {addr}")
+            while True:
+                data = self.connection.recv(4096)
+                if not data:
+                    continue
+                message = str(data, encoding="utf-8")
+                print(f"Message recieved: {message}")
+                action, parameters = self.parse_message(message)
+
+                if action is None:
+                    self.connection.send(b"!")
+                    continue
+
+                fn = self.get_function(action)
+                if fn is None:
+                    self.connection.send(b"!")
+                    continue
+
+                fn(parameters)
+                self.connection.send(b"#")
+
+    def parse_message(self, message: str) -> tuple[str | None, list]:
+        if not len(message):
+            print("[ERROR] Invalid instruction, empty message")
+            return None, []
+
+        if message[-1] != "#":
+            print("[ERROR] Invalid instruction, wrong format")
+            return None, []
+
+        instruction = message[:-1].split()
+        action, parameters = instruction[0], instruction[1:]
+        return action, parameters
+
+    def get_function(self, action) -> Callable[[any], None] | None:
+        if action not in self.function_dict.keys():
+            print(f"[ERROR] Invalid action {action}")
+            return None
+
+        return self.function_dict[action]
+
+    def get_joints(self):
+        """
+        Returns the current angles of the robots joints, in degrees.
+        """
+        print("Recieved get_joints action")
+
+    def set_joints(self, joints):
+        """
+        Executes a move immediately, from current joint angles,
+        to 'joints', in degrees.
+        """
+        print(f"Recieved set_joints action with parameters: {joints}")
+
+    def set_tool(self, tool=[[0, 0, 0], [1, 0, 0, 0]]):
+        print(f"Recieved set_tool action with parameters: {tool}")
+
+    def move_tcp(self, pose: Pose) -> None:
+        print(f"Recieved move_tcp action with parameters: {json.dumps(pose)}")
+
+
+if __name__ == "__main__":
+    server = MockServer()
+    server.run()

--- a/controllers/run_mock_server.py
+++ b/controllers/run_mock_server.py
@@ -1,0 +1,5 @@
+from mock.server import MockServer
+
+if __name__ == "__main__":
+    server = MockServer()
+    server.run()

--- a/functions/run_client.py
+++ b/functions/run_client.py
@@ -1,0 +1,7 @@
+from abb import Robot
+
+if __name__ == "__main__":
+    robot = Robot("0.0.0.0", port_motion=5000)
+    while True:
+        input("Press enter to send")
+        robot.send("hey")

--- a/functions/run_client.py
+++ b/functions/run_client.py
@@ -2,6 +2,9 @@ from abb import Robot
 
 if __name__ == "__main__":
     robot = Robot("0.0.0.0", port_motion=5000)
-    while True:
-        input("Press enter to send")
-        robot.send("hey")
+    input("Press enter to send")
+    robot.get_joints()
+    input("Press enter to send")
+    robot.set_cartesian([[0, 0, 0], [1, 0, 0, 0]])
+    input("Press enter to send")
+    robot.send("hey")

--- a/poetry.lock
+++ b/poetry.lock
@@ -4121,4 +4121,4 @@ cuda = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "930fbb946236b0c68fb7a84609dcb4303052681ccdfb99c7cb748275e1fbe2e1"
+content-hash = "f12bd82cbfa0b525b173cfbc7e3515c3ed8552b678a6bfc15e3a4c5bd07efa20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ optimum = "^1.16.2"
 openai = "^1.10.0"
 python-dotenv = "^1.0.1"
 jsonformer = {git = "https://github.com/botka1998/jsonformer.git"}
+pydantic = "^2.5.3"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Added ```MockServer``` to mock the robot controller, this server can receive instructions from ```abb.Robot``` client and print out the received instruction. 
### Usage
Implement the robot instructions as ```MockServer``` methods and add the mapping to ```MockServer.function_dict```
Reminder, instructions are in the format ```XX x1 x2 x3 ... xn #``` 
where
- XX is the function id defined by the server-client contract e.g. "00", "01"...
- x1, x2, x3 ... xn are function input parameters separated by 1 whitespace 
- \# indicates the end of an instruction string without which the instruction is invalid